### PR TITLE
 Fixed typo in heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 </head>
 
 <body>
-    <h1 class="some-heading">GIT WORKFLOW WORKSHOW</h1>
+    <h1 class="some-heading">GIT WORKFLOW WORKSHOP</h1>
 </body>
 
 </html>


### PR DESCRIPTION
Corrected word in heading - 'workshop' was incorrectly spelt as 'workshow'

Relates #3